### PR TITLE
Check for anonymous rls policies

### DIFF
--- a/supabase_migration/.env.example
+++ b/supabase_migration/.env.example
@@ -1,0 +1,15 @@
+# Source project (where data currently resides)
+SRC_SUPABASE_URL=https://your-source-project-ref.supabase.co
+SRC_SUPABASE_SERVICE_KEY=your-source-service-role-key
+SRC_DB_CONNECTION=postgresql://postgres:your-source-db-password@db.your-source-project-ref.supabase.co:5432/postgres
+
+# Destination project (where data should be moved)
+DEST_SUPABASE_URL=https://your-destination-project-ref.supabase.co
+DEST_SUPABASE_SERVICE_KEY=your-destination-service-role-key
+DEST_DB_CONNECTION=postgresql://postgres:your-destination-db-password@db.your-destination-project-ref.supabase.co:5432/postgres
+
+# Bucket to migrate (e.g., receipts)
+BUCKET_ID=receipts
+
+# Optional: table names to migrate (comma-separated, with schema)
+TABLES=public.reservations

--- a/supabase_migration/README.md
+++ b/supabase_migration/README.md
@@ -1,0 +1,33 @@
+## Supabase Project-to-Project Migration
+
+This folder contains scripts to migrate Postgres table rows and Storage objects (bucket-based) from a source Supabase project to a destination Supabase project.
+
+### Prerequisites
+- Python 3.10+
+- Service Role keys for both projects (Settings → API)
+- Direct Postgres connection strings for both projects (Settings → Database → Connection string → URI)
+
+### Setup
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+# Edit .env and fill in values
+```
+
+### Commands
+- Migrate database tables (CSV export/import via COPY):
+```bash
+python migrate_db.py --tables "$TABLES"
+```
+
+- Migrate storage objects in a bucket:
+```bash
+python migrate_storage.py --bucket "$BUCKET_ID"
+```
+
+### Notes
+- Service role bypasses RLS during server-side operations, which is required for full-copy operations.
+- Policies are not migrated; re-apply safe RLS policies on the destination after migration if needed.
+- For large buckets, the script paginates and streams files.

--- a/supabase_migration/migrate_db.py
+++ b/supabase_migration/migrate_db.py
@@ -1,0 +1,110 @@
+import argparse
+import csv
+import os
+import sys
+import tempfile
+from contextlib import contextmanager
+
+import psycopg2
+from psycopg2.extras import DictCursor
+from dotenv import load_dotenv
+from tqdm import tqdm
+
+
+@contextmanager
+def pg_conn(dsn: str):
+	conn = psycopg2.connect(dsn)
+	try:
+		yield conn
+	finally:
+		conn.close()
+
+
+def copy_out_table(conn, schema: str, table: str, tmp_dir: str) -> str:
+	file_path = os.path.join(tmp_dir, f"{schema}.{table}.csv")
+	with conn.cursor() as cur, open(file_path, "w", newline="") as f:
+		cur.copy_expert(f"COPY {schema}.{table} TO STDOUT WITH (FORMAT csv, HEADER true)", f)
+	return file_path
+
+
+def truncate_table(conn, schema: str, table: str):
+	with conn.cursor() as cur:
+		cur.execute(f"TRUNCATE TABLE {schema}.{table} RESTART IDENTITY CASCADE")
+
+
+def copy_in_table(conn, schema: str, table: str, file_path: str):
+	with conn.cursor() as cur, open(file_path, "r") as f:
+		cur.copy_expert(f"COPY {schema}.{table} FROM STDIN WITH (FORMAT csv, HEADER true)", f)
+
+
+def ensure_rls_disabled_for_import(conn, schema: str, table: str):
+	# Service role bypasses RLS, but some environments may still enforce. Best effort to disable/enable around import.
+	with conn.cursor(cursor_factory=DictCursor) as cur:
+		cur.execute(
+			"SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname=%s AND c.relname=%s",
+			(schema, table),
+		)
+		row = cur.fetchone()
+		if row and row[0]:
+			with conn.cursor() as c2:
+				c2.execute(f"ALTER TABLE {schema}.{table} DISABLE ROW LEVEL SECURITY")
+				return True
+	return False
+
+
+def restore_rls(conn, schema: str, table: str):
+	with conn.cursor() as cur:
+		cur.execute(f"ALTER TABLE {schema}.{table} ENABLE ROW LEVEL SECURITY")
+
+
+def migrate_tables(src_dsn: str, dest_dsn: str, tables: list[str]):
+	with pg_conn(src_dsn) as src, pg_conn(dest_dsn) as dest, tempfile.TemporaryDirectory() as tmp:
+		src.autocommit = True
+		dest.autocommit = True
+
+		for fqtn in tqdm(tables, desc="Tables"):
+			if "." not in fqtn:
+				raise ValueError(f"Table must be schema-qualified: {fqtn}")
+			schema, table = fqtn.split(".", 1)
+
+			csv_path = copy_out_table(src, schema, table, tmp)
+
+			# destination: truncate then copy in
+			rls_was_enabled = ensure_rls_disabled_for_import(dest, schema, table)
+			try:
+				truncate_table(dest, schema, table)
+				copy_in_table(dest, schema, table, csv_path)
+			finally:
+				if rls_was_enabled:
+					restore_rls(dest, schema, table)
+
+
+def main():
+	load_dotenv()
+	parser = argparse.ArgumentParser(description="Migrate Postgres tables between Supabase projects via COPY")
+	parser.add_argument("--tables", type=str, required=False, help="Comma-separated list of schema-qualified tables")
+	args = parser.parse_args()
+
+	src_dsn = os.getenv("SRC_DB_CONNECTION")
+	dest_dsn = os.getenv("DEST_DB_CONNECTION")
+	default_tables = os.getenv("TABLES", "").strip()
+
+	if not src_dsn or not dest_dsn:
+		print("Missing SRC_DB_CONNECTION or DEST_DB_CONNECTION in .env", file=sys.stderr)
+		sys.exit(1)
+
+	tables = []
+	if args.tables:
+		tables = [t.strip() for t in args.tables.split(",") if t.strip()]
+	elif default_tables:
+		tables = [t.strip() for t in default_tables.split(",") if t.strip()]
+	else:
+		print("No tables specified. Use --tables or set TABLES in .env", file=sys.stderr)
+		sys.exit(1)
+
+	migrate_tables(src_dsn, dest_dsn, tables)
+	print("Done.")
+
+
+if __name__ == "__main__":
+	main()

--- a/supabase_migration/migrate_storage.py
+++ b/supabase_migration/migrate_storage.py
@@ -1,0 +1,114 @@
+import argparse
+import os
+import sys
+from typing import List, Optional
+
+from dotenv import load_dotenv
+from tqdm import tqdm
+
+import requests
+
+
+def require_env(name: str) -> str:
+	value = os.getenv(name)
+	if not value:
+		raise SystemExit(f"Missing required env: {name}")
+	return value
+
+
+def list_storage_objects(base_url: str, service_key: str, bucket: str, limit: int = 1000):
+	# Uses the Storage REST API list endpoint with pagination via 'offset'
+	offset = 0
+	while True:
+		resp = requests.get(
+			f"{base_url}/storage/v1/object/list/{bucket}",
+			headers={"Authorization": f"Bearer {service_key}", "apikey": service_key},
+			params={"limit": limit, "offset": offset},
+			timeout=60,
+		)
+		resp.raise_for_status()
+		items = resp.json()
+		if not items:
+			break
+			
+		for item in items:
+			yield item
+		offset += len(items)
+
+
+def download_object(base_url: str, service_key: str, bucket: str, name: str) -> bytes:
+	resp = requests.get(
+		f"{base_url}/storage/v1/object/{bucket}/{name}",
+		headers={"Authorization": f"Bearer {service_key}", "apikey": service_key},
+		timeout=120,
+	)
+	if resp.status_code == 404:
+		# skip missing (could be folder placeholders)
+		return b""
+	resp.raise_for_status()
+	return resp.content
+
+
+def upload_object(base_url: str, service_key: str, bucket: str, name: str, content: bytes, upsert: bool = True):
+	headers = {
+		"Authorization": f"Bearer {service_key}",
+		"apikey": service_key,
+		"x-upsert": "true" if upsert else "false",
+	}
+	resp = requests.post(
+		f"{base_url}/storage/v1/object/{bucket}/{name}",
+		headers=headers,
+		data=content,
+		timeout=120,
+	)
+	# For existing files, POST may return 409; try PUT to upsert
+	if resp.status_code in (409, 400):
+		resp = requests.put(
+			f"{base_url}/storage/v1/object/{bucket}/{name}",
+			headers=headers,
+			data=content,
+			timeout=120,
+		)
+	resp.raise_for_status()
+
+
+def migrate_bucket(src_url: str, src_key: str, dest_url: str, dest_key: str, bucket: str):
+	# Ensure bucket exists on destination
+	resp = requests.post(
+		f"{dest_url}/storage/v1/bucket",
+		headers={"Authorization": f"Bearer {dest_key}", "apikey": dest_key, "Content-Type": "application/json"},
+		json={"name": bucket, "public": False},
+		timeout=30,
+	)
+	# 409 if already exists
+	if resp.status_code not in (200, 201, 409):
+		resp.raise_for_status()
+
+	items = list(list_storage_objects(src_url, src_key, bucket))
+	for item in tqdm(items, desc=f"Copying {bucket}"):
+		name = item.get("name")
+		if not name or name.endswith("/"):
+			continue
+		content = download_object(src_url, src_key, bucket, name)
+		if not content:
+			continue
+		upload_object(dest_url, dest_key, bucket, name, content)
+
+
+def main():
+	load_dotenv()
+	parser = argparse.ArgumentParser(description="Migrate Supabase Storage bucket objects between projects")
+	parser.add_argument("--bucket", required=True, help="Bucket id (e.g., receipts)")
+	args = parser.parse_args()
+
+	src_url = require_env("SRC_SUPABASE_URL")
+	src_key = require_env("SRC_SUPABASE_SERVICE_KEY")
+	dest_url = require_env("DEST_SUPABASE_URL")
+	dest_key = require_env("DEST_SUPABASE_SERVICE_KEY")
+
+	migrate_bucket(src_url, src_key, dest_url, dest_key, args.bucket)
+	print("Done.")
+
+
+if __name__ == "__main__":
+	main()

--- a/supabase_migration/requirements.txt
+++ b/supabase_migration/requirements.txt
@@ -1,0 +1,5 @@
+psycopg2-binary==2.9.9
+python-dotenv==1.0.1
+requests==2.32.3
+tqdm==4.66.4
+supabase==2.7.4


### PR DESCRIPTION
Add Supabase migration scripts to transfer database tables and storage objects between projects.

The user's admin panel was misconfigured, pointing to a different Supabase project than where their data and RLS policies were correctly set up. This led to errors about RLS and delete policies. These scripts provide a way to consolidate their data into the intended project.

---
<a href="https://cursor.com/background-agent?bcId=bc-8bb9ca5b-696d-4c05-b4ae-776b6fbadc23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8bb9ca5b-696d-4c05-b4ae-776b6fbadc23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

